### PR TITLE
Piccole revisioni

### DIFF
--- a/ETLC.tex
+++ b/ETLC.tex
@@ -128,7 +128,7 @@ Elettronica per le Radiofrequenze", a cura di Ing. M. Mincica e Ing. A. Fonte;
 \item ``Microwave Engineering" - D. Pozar
 \end{itemize}
 
-\textbf{Immagini} realizzate con Digikey\textregistered Scheme-It\textregistered ed Inkscape
+\textbf{Immagini} realizzate con Digikey\textregistered Scheme-It\textregistered ~ed Inkscape
 
 \textbf{Impaginazione} in \LaTeX
 
@@ -393,8 +393,8 @@ $$
 	
 	\section{Guadagni e definizioni}
 	
-	\paragraph{Rete reciproca:} una rete due porte è reciproca quando, posto un generatore sulla porta 1 e misurata la corrente sulla porta 2, si osserva la stessa corrente scambiando le porte. Di conseguenza le matrici Z ed Y sono simmetriche. Le reti con soli componenti passivi sono usualmente reciproche.
-	\paragraph{Rete simmetrica:} un due porte è simmetrico l'impedenza d'ingresso è uguale a quella di uscita; in altri termini, un generatore di prova posto sulla porta 1 o sulla porta 2 è attraversato da pari corrente. Di conseguenza nelle matrici Z o Y i termini 11 sono uguali ai 22.
+	\paragraph{Rete reciproca:} una rete due porte è reciproca quando, posto un generatore di tensione sulla porta 1 e misurata la corrente sulla porta 2, questa risulta pari alla corrente misurata scambiando le porte. Di conseguenza le matrici Z ed Y sono simmetriche (i termini incrociati coincidono). Le reti con soli componenti passivi sono usualmente reciproche.
+	\paragraph{Rete simmetrica:} un due porte è simmetrico quando l'impedenza d'ingresso è uguale a quella di uscita; in altri termini, lo stesso generatore di prova posto sulla porta 1 o sulla porta 2 è attraversato da pari corrente. Di conseguenza nelle matrici Z o Y i termini 11 sono uguali ai 22.
 	
 	\begin{figure}[hb]
 		\centering


### PR DESCRIPTION
Rivista definizione di rete reciproca e simmetrica. Aggiunto spazio mancante in seconda di copertina.